### PR TITLE
Try to fix the fp2bit funtion in sim.R. from Songpeng

### DIFF
--- a/R/sim.R
+++ b/R/sim.R
@@ -617,8 +617,7 @@ fp2bit <- function(x, type=3, fptag="PUBCHEM_CACTVS_SUBSKEYS") {
 	}
 	fpma <- unlist(strsplit(fp, ""))
 	fpma <- matrix(fpma, length(fp), nchar(fp[1]), byrow=TRUE)
-	fpma <- fpma[, 1:154] # remove padding signs '='
-	fpma <- matrix(fpma,length(fp),byrow=TRUE) # Keep the fpma as matrix all the time.
+	fpma <- fpma[, 1:154, drop=FALSE] # remove padding signs '='
 
 	## base 64 decoding (base 64 alphabet from http://www.faqs.org/rfcs/rfc3548.html)
 	base64 <- c(A=0,B=1,C=2,D=3,E=4,F=5,G=6,H=7,I=8,J=9,K=10,L=11,M=12,N=13,O=14,P=15,
@@ -628,8 +627,7 @@ fp2bit <- function(x, type=3, fptag="PUBCHEM_CACTVS_SUBSKEYS") {
                     "4"=56,"5"=57,"6"=58,"7"=59,"8"=60,"9"=61,"+"=62,"/"=63)
 	fpbitma <- as.integer(intToBits(base64[as.vector(t(fpma))]))
 	fpbitma <- matrix(fpbitma, length(fpma[,1])*154, 32, byrow=TRUE)[,6:1]
-	fpbitma <- matrix(t(fpbitma), length(fpma[,1]), 6*154, byrow=TRUE)[,33:913]
-	fpbitma <- matrix(fpbitma, length(fpma[,1]), byrow=TRUE) # Keep fpbitma as matrix all the time.
+	fpbitma <- matrix(t(fpbitma), length(fpma[,1]), 6*154, byrow=TRUE)[,33:913,drop=FALSE]
         pubchemFP <- pubchemFPencoding[,2]
 	names(pubchemFP) <- pubchemFPencoding[,1]
 	colnames(fpbitma) <- pubchemFP

--- a/R/sim.R
+++ b/R/sim.R
@@ -618,6 +618,7 @@ fp2bit <- function(x, type=3, fptag="PUBCHEM_CACTVS_SUBSKEYS") {
 	fpma <- unlist(strsplit(fp, ""))
 	fpma <- matrix(fpma, length(fp), nchar(fp[1]), byrow=TRUE)
 	fpma <- fpma[, 1:154] # remove padding signs '='
+	fpma <- matrix(fpma,length(fp),byrow=TRUE) # Keep the fpma as matrix all the time.
 
 	## base 64 decoding (base 64 alphabet from http://www.faqs.org/rfcs/rfc3548.html)
 	base64 <- c(A=0,B=1,C=2,D=3,E=4,F=5,G=6,H=7,I=8,J=9,K=10,L=11,M=12,N=13,O=14,P=15,
@@ -628,6 +629,7 @@ fp2bit <- function(x, type=3, fptag="PUBCHEM_CACTVS_SUBSKEYS") {
 	fpbitma <- as.integer(intToBits(base64[as.vector(t(fpma))]))
 	fpbitma <- matrix(fpbitma, length(fpma[,1])*154, 32, byrow=TRUE)[,6:1]
 	fpbitma <- matrix(t(fpbitma), length(fpma[,1]), 6*154, byrow=TRUE)[,33:913]
+	fpbitma <- matrix(fpbitma, length(fpma[,1]), byrow=TRUE) # Keep fpbitma as matrix all the time.
         pubchemFP <- pubchemFPencoding[,2]
 	names(pubchemFP) <- pubchemFPencoding[,1]
 	colnames(fpbitma) <- pubchemFP


### PR DESCRIPTION
When sdfset only contains one SDF element, fp2bit will get Error " fpma[ ,1]: incorrect number of dimensions."
This is because the fpma[ , 1:154] in function fp2bit will return an array, if  fpma only has one row.
The same as fpbitma.

I try to fix this "bug" (I treat it as a bug), and I wonder whether it works for you?
Also I am new about github, and sorry for any possible trouble.  
